### PR TITLE
Store the dates as MMM dd yyyy format

### DIFF
--- a/data/ollie.txt
+++ b/data/ollie.txt
@@ -1,3 +1,3 @@
-TODO | X | study
-DEADLINE |   | assignment | sunday
-EVENT |   | meet parents | sat | evening
+EVENT |   | meeting | Aug 25 2024 09:30 | Aug 25 2024 11:00
+DEADLINE |   | assignment | Aug 25 2024 14:00
+DEADLINE |   | work | Aug 27 2024 08:00

--- a/src/main/java/Deadline.java
+++ b/src/main/java/Deadline.java
@@ -1,8 +1,11 @@
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 /**
  * Represents a Deadline task with a description and a due date.
  */
 public class Deadline extends Task {
-    private String deadline;
+    private LocalDateTime deadline;
 
     /**
      * Constructs a Deadline task with the specified description and due date.
@@ -10,7 +13,7 @@ public class Deadline extends Task {
      * @param description The description of the Deadline task.
      * @param deadline The due date of the Deadline task.
      */
-    public Deadline(String description, String deadline) {
+    public Deadline(String description, LocalDateTime deadline) {
         super(description, TaskType.DEADLINE);
         this.deadline = deadline;
     }
@@ -32,18 +35,27 @@ public class Deadline extends Task {
     public static Deadline createTask(String command) throws OllieException {
         String[] parts = command.substring(8).split(" /by:");
         if (parts.length != 2) {
-            throw new OllieException("Please enter in the format:\n" + "deadline task_name /by: due_date");
+            throw new OllieException("Please enter in the format:\n" +
+                    "deadline task_name /by: due_date" +
+                    "\nExample: deadline assignment /by: 2021-09-30 23:59");
         }
-        return new Deadline(parts[0].trim(), parts[1].trim());
+        DateTimeFormatter inputDate = getInputDate();
+        try {
+            return new Deadline(parts[0].trim(), LocalDateTime.parse(parts[1].trim(), inputDate));
+        } catch (Exception e) {
+            throw new OllieException("Please enter the date in the format: yyyy-MM-dd HH:mm");
+        }
     }
 
     @Override
     public String saveAsString() {
-        return String.format("%s | %s", super.saveAsString(), deadline);
+        DateTimeFormatter formatDate = getFormatDate();
+        return String.format("%s | %s", super.saveAsString(), deadline.format(formatDate));
     }
 
     @Override
     public String toString() {
-        return super.toString() + " (by: " + deadline + ")";
+        DateTimeFormatter formatDate = getFormatDate();
+        return super.toString() + " (by: " + deadline.format(formatDate) + ")";
     }
 }

--- a/src/main/java/Event.java
+++ b/src/main/java/Event.java
@@ -1,9 +1,12 @@
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 /**
  * Represents an Event task with a description, start time, and end time.
  */
 public class Event extends Task {
-    private String start;
-    private String end;
+    private LocalDateTime start;
+    private LocalDateTime end;
 
     /**
      * Constructs an Event task with the specified description, start time, and end time.
@@ -12,7 +15,7 @@ public class Event extends Task {
      * @param start The start time of the Event.
      * @param end The end time of the Event.
      */
-    public Event(String description, String start, String end) {
+    public Event(String description, LocalDateTime start, LocalDateTime end) {
         super(description, TaskType.EVENT);
         this.start = start;
         this.end = end;
@@ -38,18 +41,28 @@ public class Event extends Task {
     public static Event createTask(String command) throws OllieException {
         String[] parts = command.substring(5).split(" /from:| /to:");
         if (parts.length != 3) {
-            throw new OllieException("Please enter in the format:\n" + "event event_name /from: start_time /to: end_time");
+            throw new OllieException("Please enter in the format:\n" +
+                    "event event_name /from: start_time /to: end_time" +
+                    "\nExample: event meeting /from: 2021-09-30 14:00 /to: 2021-09-30 15:00");
         }
-        return new Event(parts[0].trim(), parts[1].trim(), parts[2].trim());
+        DateTimeFormatter inputDate = getInputDate();
+        try {
+            return new Event(parts[0].trim(), LocalDateTime.parse(parts[1].trim(), inputDate),
+                    LocalDateTime.parse(parts[2].trim(), inputDate));
+        } catch (Exception e) {
+            throw new OllieException("Please enter the date in the format: yyyy-MM-dd HH:mm");
+        }
     }
 
     @Override
     public String saveAsString() {
-        return String.format("%s | %s | %s", super.saveAsString(), start, end);
+        DateTimeFormatter formatDate = getFormatDate();
+        return String.format("%s | %s | %s", super.saveAsString(), start.format(formatDate), end.format(formatDate));
     }
 
     @Override
     public String toString() {
-        return super.toString() + " (from: " + start + " to: " + end + ")";
+        DateTimeFormatter formatDate = getFormatDate();
+        return super.toString() + " (from: " + start.format(formatDate) + " to: " + end.format(formatDate) + ")";
     }
 }

--- a/src/main/java/Ollie.java
+++ b/src/main/java/Ollie.java
@@ -109,7 +109,7 @@ public class Ollie {
 
         String command;
         Scanner input = new Scanner(System.in);
-
+        
         do {
             command = input.nextLine();
             ollie.respond(command);

--- a/src/main/java/Storage.java
+++ b/src/main/java/Storage.java
@@ -3,6 +3,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Scanner;
+import java.time.LocalDateTime;
 
 /**
  * Represents a storage which stores all the tasks.
@@ -68,10 +69,11 @@ public class Storage {
                     task = new Todo(description);
                     break;
                 case "DEADLINE":
-                    task = new Deadline(description, date);
+                    task = new Deadline(description, LocalDateTime.parse(date, Task.getFormatDate()));
                     break;
                 case "EVENT":
-                    task = new Event(description, date, end);
+                    task = new Event(description, LocalDateTime.parse(date, Task.getFormatDate()),
+                            LocalDateTime.parse(end, Task.getFormatDate()));
                     break;
                 default:
                     throw new OllieException("Oops! Invalid task type detected: " + taskType);

--- a/src/main/java/Task.java
+++ b/src/main/java/Task.java
@@ -1,3 +1,5 @@
+import java.time.format.DateTimeFormatter;
+
 /**
  * Represents a generic task with a description and completion status.
  */
@@ -5,6 +7,8 @@ public abstract class Task {
     protected String description;
     protected boolean isDone;
     protected TaskType taskType;
+    private static final DateTimeFormatter inputDate = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+    private static final DateTimeFormatter formatDate = DateTimeFormatter.ofPattern("MMM dd yyyy HH:mm");
 
     /**
      * Constructs a Task with the specified description and type.
@@ -25,6 +29,24 @@ public abstract class Task {
      */
     public String getStatusIcon() {
         return (isDone ? "X" : " ");
+    }
+
+    /**
+     * Returns the DateTimeFormatter instance for the date input by the user
+     *
+     * @return inputDate the DateTimeFormatter instance with the pattern "yyyy-MM-dd HH:mm".
+     */
+    public static DateTimeFormatter getInputDate() {
+        return inputDate;
+    }
+
+    /**
+     * Returns the DateTimeFormatter instance for the date output by the program
+     *
+     * @return formatDate the DateTimeFormatter instance with the pattern "MMM dd yyyy HH:mm".
+     */
+    public static DateTimeFormatter getFormatDate() {
+        return formatDate;
     }
 
     /**

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -11,21 +11,21 @@ Please enter in the format:
 event event_name /from: start_time /to: end_time
 ____________________________________________________________
 Got it. I've added this task ☺:
-  [ ] [EVENT] meeting (from: Thursday 5pm to: 6pm)
+  [ ] [EVENT] meeting (from: Aug 25 2024 09:30 to: Aug 25 2024 11:00)
 Now you have 2 tasks in the list. ☺
 ____________________________________________________________
 Please enter in the format:
 deadline task_name /by: due_date
 ____________________________________________________________
 Got it. I've added this task ☺:
-  [ ] [DEADLINE] assignment (by: Friday)
+  [ ] [DEADLINE] assignment (by: Aug 25 2024 14:00)
 Now you have 3 tasks in the list. ☺
 ____________________________________________________________
 ------------------------------------------------------------
 Here are the tasks in your list ☺ :
 1. [ ] [TODO] study
-2. [ ] [EVENT] meeting (from: Thursday 5pm to: 6pm)
-3. [ ] [DEADLINE] assignment (by: Friday)
+2. [ ] [EVENT] meeting (from: Aug 25 2024 09:30 to: Aug 25 2024 11:00)
+3. [ ] [DEADLINE] assignment (by: Aug 25 2024 14:00)
 ------------------------------------------------------------
 ____________________________________________________________
 Nice! ☺ I've marked this task as done ☺ :
@@ -34,8 +34,8 @@ ____________________________________________________________
 ------------------------------------------------------------
 Here are the tasks in your list ☺ :
 1. [X] [TODO] study
-2. [ ] [EVENT] meeting (from: Thursday 5pm to: 6pm)
-3. [ ] [DEADLINE] assignment (by: Friday)
+2. [ ] [EVENT] meeting (from: Aug 25 2024 09:30 to: Aug 25 2024 11:00)
+3. [ ] [DEADLINE] (by: Aug 25 2024 14:00)
 ------------------------------------------------------------
 ____________________________________________________________
 OK, I've marked this task as not done yet:
@@ -43,13 +43,13 @@ OK, I've marked this task as not done yet:
 ____________________________________________________________
 ____________________________________________________________
 Noted. I've removed this task:
-  [ ] [EVENT] meeting (from: Thursday 5pm to: 6pm)
+  [ ] [EVENT] meeting (from: Aug 25 2024 09:30 to: Aug 25 2024 11:00)
 Now you have 2 tasks in the list.
 ____________________________________________________________
 ------------------------------------------------------------
 Here are the tasks in your list ☺ :
 1. [ ] [TODO] study
-2. [ ] [DEADLINE] assignment (by: Friday)
+2. [ ] [DEADLINE] (by: Aug 25 2024 14:00)
 ------------------------------------------------------------
 Bye. Have a great day. ☺
 Hope to see you again soon! ☺

--- a/text-ui-test/input.txt
+++ b/text-ui-test/input.txt
@@ -1,9 +1,9 @@
 todo
 todo study
 event
-event meeting /from: Thursday 5pm /to: 6pm
+event meeting /from: 2024-08-25 09:30 /to: 2024-08-25 11:00
 deadline
-deadline assignment /by: Friday
+deadline assignment /by: 2024-08-25 14:00
 list
 mark 1
 list


### PR DESCRIPTION
**Current Situation**
The deadlines and dates are stored as strings.

**Why it needs to change**
The chatbot should understand 2/12/2019 1800 as 2nd of December 2019, 6pm, instead of treating it as just a String.

**What is being done about it**
* Store deadline dates as a java.time.LocalDateTime
* The user inputs the time in the format yyyy-MM-dd HH:mm
* The time is saved and loaded in the format MMM dd yyyy HH:mm

**Why it is done that way**
* It makes it clearer and more use to the user