### PR TITLE
Add JavaDoc comments to the classes and methods

### DIFF
--- a/src/main/java/ollie/Ollie.java
+++ b/src/main/java/ollie/Ollie.java
@@ -8,7 +8,7 @@ public class Ollie {
     private Ui ui;
 
     /**
-     * Constructs an ollie.Ollie instance with a new ollie.TaskList.
+     * Constructs an Ollie instance with a new TaskList.
      */
     public Ollie() {
         ui = new Ui();
@@ -22,9 +22,9 @@ public class Ollie {
     }
 
     /**
-     * The main method that runs the ollie.Ollie task manager.
+     * The main method that runs the Ollie task manager.
      *
-     * @param args ollie.Command-line arguments (not used).
+     * @param args Command-line arguments.
      */
     public static void main(String[] args) throws OllieException {
         Ollie ollie = new Ollie();

--- a/src/main/java/ollie/Parser.java
+++ b/src/main/java/ollie/Parser.java
@@ -4,7 +4,7 @@ import ollie.exception.OllieException;
 import ollie.exception.UnknownTaskTypeException;
 
 /**
- * Deals with making sense of the user command.
+ * The Parser class deals with making sense of the user command.
  */
 public class Parser {
 

--- a/src/main/java/ollie/Storage.java
+++ b/src/main/java/ollie/Storage.java
@@ -14,8 +14,8 @@ import java.util.Scanner;
 import java.time.LocalDateTime;
 
 /**
- * Represents a storage which stores all the tasks.
- * Allows the user to save and load the list of tasks from a file.
+ * The Storage class represents a storage which stores all the tasks.
+ * It allows the user to save and load the list of tasks from a file.
  */
 public class Storage {
 

--- a/src/main/java/ollie/TaskList.java
+++ b/src/main/java/ollie/TaskList.java
@@ -6,7 +6,7 @@ import ollie.task.Task;
 import java.util.ArrayList;
 
 /**
- * Manages a list of tasks.
+ * The TaskList manages a list of tasks.
  */
 public class TaskList {
     private ArrayList<Task> tasks;
@@ -24,6 +24,7 @@ public class TaskList {
     /**
      * Constructs a ollie.TaskList and loads tasks from storage.
      * If the storage file does not exist, an empty list is created.
+     *
      * @param tasks The list of tasks.
      * @param storage The storage object for saving and loading tasks.
      */
@@ -44,6 +45,7 @@ public class TaskList {
 
     /**
      * Returns the list of tasks.
+     *
      * @return The list of tasks.
      */
     public ArrayList<Task> getTasks() {

--- a/src/main/java/ollie/Ui.java
+++ b/src/main/java/ollie/Ui.java
@@ -9,7 +9,7 @@ import ollie.task.Todo;
 import java.util.Scanner;
 
 /**
- * Handles all interactions with the user.
+ * The Ui class handles all interactions with the user.
  */
 public class Ui {
     private final Scanner scanner;
@@ -122,7 +122,7 @@ public class Ui {
     }
 
     /**
-     * Sets the ollie.TaskList for this UI instance.
+     * Sets the TaskList for this UI instance.
      *
      * @param taskList The ollie.TaskList to set.
      */

--- a/src/main/java/ollie/exception/EmptyDescriptionException.java
+++ b/src/main/java/ollie/exception/EmptyDescriptionException.java
@@ -1,11 +1,13 @@
 package ollie.exception;
 
 /**
- * Exception thrown when a task description is empty.
+ * The EmptyDescriptionException exception is thrown when a task description is empty.
  */
 public class EmptyDescriptionException extends OllieException {
+
     /**
-     * Constructs an ollie.exception.EmptyDescriptionException with a predefined message based on the task type.
+     * Constructs an ollie.exception.EmptyDescriptionException.
+     * It has a predefined message based on the task type.
      *
      * @param taskType the type of task that caused the exception
      */

--- a/src/main/java/ollie/exception/OllieException.java
+++ b/src/main/java/ollie/exception/OllieException.java
@@ -1,13 +1,15 @@
 package ollie.exception;
 
 /**
- * Represents a general exception in the ollie.Ollie chatbot.
+ * OllieException is an exception that is thrown when an error occurs.
  */
 public class OllieException extends Exception {
+
     /**
-     * Constructs an ollie.exception.OllieException with the specified detail message.
+     * Constructs an ollie.exception.OllieException
+     * The message can be specified to describe the error.
      *
-     * @param message the detail message
+     * @param message the message describing the error
      */
     public OllieException(String message) {
         super(message);

--- a/src/main/java/ollie/exception/UnknownTaskTypeException.java
+++ b/src/main/java/ollie/exception/UnknownTaskTypeException.java
@@ -3,9 +3,10 @@ package ollie.exception;
 import ollie.exception.OllieException;
 
 /**
- * Exception thrown when an unknown task type is provided.
+ * UnknownTaskTypeException is an exception thrown when an unknown task type is provided.
  */
 public class UnknownTaskTypeException extends OllieException {
+
     /**
      * Constructs an ollie.exception.UnknownTaskTypeException with a predefined message.
      */

--- a/src/main/java/ollie/task/Deadline.java
+++ b/src/main/java/ollie/task/Deadline.java
@@ -8,22 +8,29 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 /**
- * Represents a ollie.task.Deadline task with a description and a due date.
+ * Deadline is a type of Task.
+ * It represents a task with a description and a due date.
  */
 public class Deadline extends Task {
     private LocalDateTime deadline;
 
     /**
-     * Constructs a ollie.task.Deadline task with the specified description and due date.
+     * Constructs a Deadline task with the specified description and due date.
      *
-     * @param description The description of the ollie.task.Deadline task.
-     * @param deadline The due date of the ollie.task.Deadline task.
+     * @param description The description of the Deadline task.
+     * @param deadline The due date of the Deadline task.
      */
     public Deadline(String description, LocalDateTime deadline) {
         super(description, TaskType.DEADLINE);
         this.deadline = deadline;
     }
 
+    /**
+     * Validates the description of the Deadline task.
+     *
+     * @param command The command entered by the user.
+     * @throws OllieException If the description is empty or the deadline is not provided.
+     */
     @Override
     public void validateDescription(String command) throws OllieException {
         String[] parts = command.split(" /by ");
@@ -38,6 +45,13 @@ public class Deadline extends Task {
         }
     }
 
+    /**
+     * Creates a Deadline task from the specified command.
+     *
+     * @param command The command entered by the user.
+     * @return The Deadline task created from the command.
+     * @throws OllieException If the command is in the wrong format or the date is invalid.
+     */
     public static Deadline createTask(String command) throws OllieException {
         String[] parts = command.substring(8).split(" /by:");
         if (parts.length != 2) {
@@ -54,20 +68,26 @@ public class Deadline extends Task {
     }
 
     /**
-     * Returns the due date of the ollie.task.Deadline task.
+     * Returns the due date of the Deadline task.
      *
-     * @return deadline of the ollie.task.Deadline task.
+     * @return deadline of the Deadline task.
      */
     public LocalDateTime getDeadline() {
         return deadline;
     }
 
+    /**
+     * @inheritDoc
+     */
     @Override
     public String saveAsString() {
         DateTimeFormatter formatDate = Task.getFormatDate();
         return String.format("%s | %s", super.saveAsString(), deadline.format(formatDate));
     }
 
+    /**
+     * @inheritDoc
+     */
     @Override
     public String toString() {
         DateTimeFormatter formatDate = Task.getFormatDate();

--- a/src/main/java/ollie/task/Event.java
+++ b/src/main/java/ollie/task/Event.java
@@ -8,18 +8,19 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 /**
- * Represents an ollie.task.Event task with a description, start time, and end time.
+ * Event is a type of Task.
+ * It represents a task with a description, start time, and end time.
  */
 public class Event extends Task {
     private LocalDateTime start;
     private LocalDateTime end;
 
     /**
-     * Constructs an ollie.task.Event task with the specified description, start time, and end time.
+     * Constructs an Event with the specified description, start time, and end time.
      *
-     * @param description The description of the ollie.task.Event task.
-     * @param start The start time of the ollie.task.Event.
-     * @param end The end time of the ollie.task.Event.
+     * @param description The description of the Event.
+     * @param start The start time of the Event.
+     * @param end The end time of the Event.
      */
     public Event(String description, LocalDateTime start, LocalDateTime end) {
         super(description, TaskType.EVENT);
@@ -28,23 +29,29 @@ public class Event extends Task {
     }
 
     /**
-     * Returns the start time of the ollie.task.Event task.
+     * Returns the start time of the Event.
      *
-     * @return start of the ollie.task.Event task.
+     * @return start of the Event.
      */
     public LocalDateTime getStart() {
         return start;
     }
 
     /**
-     * Returns the end time of the ollie.task.Event task.
+     * Returns the end time of the Event.
      *
-     * @return end of the ollie.task.Event task.
+     * @return end of the Event.
      */
     public LocalDateTime getEnd() {
         return end;
     }
 
+    /**
+     * Validates the description of the Event task.
+     *
+     * @param command The command entered by the user.
+     * @throws OllieException If the description is empty or the start time and end time are not provided.
+     */
     @Override
     public void validateDescription(String command) throws OllieException {
         String[] parts = command.split(" /from | /to ");
@@ -62,6 +69,13 @@ public class Event extends Task {
         }
     }
 
+    /**
+     * Creates an Event from the specified command.
+     *
+     * @param command The command entered by the user.
+     * @return The Event task created from the command.
+     * @throws OllieException If the command is in the wrong format or the date is invalid.
+     */
     public static Event createTask(String command) throws OllieException {
         String[] parts = command.substring(5).split(" /from:| /to:");
         if (parts.length != 3) {
@@ -78,12 +92,22 @@ public class Event extends Task {
         }
     }
 
+    /**
+     * Saves the Event as a string for storage.
+     *
+     * @return The Event as a string.
+     */
     @Override
     public String saveAsString() {
         DateTimeFormatter formatDate = Task.getFormatDate();
         return String.format("%s | %s | %s", super.saveAsString(), start.format(formatDate), end.format(formatDate));
     }
 
+    /**
+     * Returns the string representation of the Event.
+     *
+     * @return The string representation of the Event.
+     */
     @Override
     public String toString() {
         DateTimeFormatter formatDate = Task.getFormatDate();

--- a/src/main/java/ollie/task/Task.java
+++ b/src/main/java/ollie/task/Task.java
@@ -6,7 +6,7 @@ import ollie.TaskType;
 import java.time.format.DateTimeFormatter;
 
 /**
- * Represents a generic task with a description and completion status.
+ * The Task class represents a generic task with a description and completion status.
  */
 public abstract class Task {
     protected String description;
@@ -16,7 +16,7 @@ public abstract class Task {
     private static final DateTimeFormatter formatDate = DateTimeFormatter.ofPattern("MMM dd yyyy HH:mm");
 
     /**
-     * Constructs a ollie.task.Task with the specified description and type.
+     * Constructs a Task with the specified description and type.
      *
      * @param description The description of the task.
      * @param taskType The type of the task.
@@ -79,6 +79,11 @@ public abstract class Task {
         return String.format("%s | %s | %s", taskType, getStatusIcon(), description);
     }
 
+    /**
+     * Returns the string representation of the task.
+     *
+     * @return The string representation of the task.
+     */
     @Override
     public String toString() {
         return "[" + getStatusIcon() + "] " + "[" + taskType + "] " + description;

--- a/src/main/java/ollie/task/Todo.java
+++ b/src/main/java/ollie/task/Todo.java
@@ -4,19 +4,26 @@ import ollie.exception.EmptyDescriptionException;
 import ollie.TaskType;
 
 /**
- * Represents a ollie.task.Todo task with only a description.
+ * Todo is a type of Task.
+ * It represents a task with a description.
  */
 public class Todo extends Task {
 
     /**
-     * Constructs a ollie.task.Todo task with the specified description.
+     * Constructs a Todo with the specified description.
      *
-     * @param description The description of the ollie.task.Todo task.
+     * @param description The description of the Todo.
      */
     public Todo(String description) {
         super(description, TaskType.TODO);
     }
 
+    /**
+     * Validates the description of the Todo task.
+     *
+     * @param command The command entered by the user.
+     * @throws EmptyDescriptionException If the description is empty.
+     */
     @Override
     public void validateDescription(String command) throws EmptyDescriptionException {
         if (command.trim().isEmpty()) {
@@ -24,6 +31,13 @@ public class Todo extends Task {
         }
     }
 
+    /**
+     * Creates a Todo task from the specified command.
+     *
+     * @param command The command entered by the user.
+     * @return The Todo task created from the command.
+     * @throws EmptyDescriptionException If the description is empty.
+     */
     public static Todo createTask(String command) throws EmptyDescriptionException {
         String description = command.substring(4).trim();
         if (description.isEmpty()) {
@@ -32,11 +46,21 @@ public class Todo extends Task {
         return new Todo(description);
     }
 
+    /**
+     * Saves the Todo task as a string for storage.
+     *
+     * @return The Todo task as a string.
+     */
     @Override
     public String saveAsString() {
         return super.saveAsString();
     }
 
+    /**
+     * Returns the string representation of the Todo task.
+     *
+     * @return The string representation of the Todo task.
+     */
     @Override
     public String toString() {
         return super.toString();


### PR DESCRIPTION
**Current Situation**
* Not all classes and methods have Javadoc comments

**Why it needs to change**
* The comments help to tell readers what the code does.

**What is being done about it**
* Let's add header comments to at least half of the non-private classes/methods.

**Why it is done that way**
* It makes the code more understandable to others.