### PR TITLE
Update .gitignore to exclude the txt files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 /build/
 src/main/resources/docs/
 
+#.txt input and output files
+*.txt
+
 # MacOS custom attributes files created by Finder
 .DS_Store
 *.iml


### PR DESCRIPTION
The txt files are included when a commit is pushed, but it is unnecessary

Let's 
* Include the .txt files in .gitignore so that they will not be kept track of